### PR TITLE
refactor: remove process.env in nuxt.config

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -51,14 +51,14 @@ export default defineNuxtConfig({
   },
 
   runtimeConfig: {
-    sessionPassword: process.env.NUXT_SESSION_PASSWORD,
-    githubClientSecret: process.env.NUXT_OAUTH_GITHUB_CLIENT_SECRET,
+    sessionPassword: "",
+    githubClientSecret: "",
 
     public: {
-      youtubeApiBaseUrl: process.env.NUXT_YOUTUBE_API_BASE_URL,
-      youtubeApiKey: process.env.NUXT_YOUTUBE_API_KEY,
-      youtubeChannelId: process.env.NUXT_YOUTUBE_CHANNEL_ID,
-      githubClientId: process.env.NUXT_OAUTH_GITHUB_CLIENT_ID,
+      youtubeApiBaseUrl: "",
+      youtubeApiKey: "",
+      youtubeChannelId: "",
+      githubClientId: "",
     },
   },
 });


### PR DESCRIPTION
Hey 👋,

This PR removes the usage of `process.env` in the `nuxt.config.ts` file as it can lead to many issues and unwanted behavior. Instead, you should let Nuxt retrieving the environment variables for you.

For more information, see [Nuxt's runtimeConfig - The most common mistake](https://www.youtube.com/watch?v=_FYV5WfiWvs) from Alexander Lichter or this section of the [Nuxt API documentation](https://nuxt.com/docs/api/nuxt-config#runtimeconfig-1).
