### PR TITLE
fix: headers flickering

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -1,20 +1,13 @@
-<script setup lang="ts">
-const { width } = useWindowSize();
-
-const isMobile = computed(() => width.value < 768);
-</script>
+<script setup lang="ts"></script>
 
 <template>
   <div>
-    <ClientOnly>
-      <AppHeader v-if="!isMobile" />
-    </ClientOnly>
+    <AppHeader class="hidden md:flex" />
     <main>
       <slot />
     </main>
     <AppFooter />
-    <ClientOnly>
-      <MobileHeader v-if="isMobile" />
-    </ClientOnly>
+
+    <MobileHeader class="block md:hidden" />
   </div>
 </template>


### PR DESCRIPTION
Hello 👋,

This PR fixes the headers (mobile and desktop) flickering.

Using the `ClientOnly` component means that the template is only evaluated client-side. This is actually an issue because the page comes without it and then it's added, causing the flickering, where the page "jump" during the loading.

You can simply use some CSS to hide the unwanted content. This works because the CSS is evaluated before the page is rendered (created and shown to the user).
