### PR TITLE
fix: move padding to anchor

### DIFF
--- a/components/AppHeader.vue
+++ b/components/AppHeader.vue
@@ -4,36 +4,45 @@ const route = useRoute();
 
 <template>
   <header
-    class="sticky top-0 z-30 flex w-full items-center justify-between bg-white py-5 text-secondary shadow-md lg:px-20 dark:bg-slate-800 dark:text-white"
+    class="sticky top-0 z-30 flex w-full items-center justify-between bg-white py-5 text-secondary shadow-md dark:bg-slate-800 dark:text-white lg:px-20"
   >
     <nav>
       <ul class="flex gap-5 text-xl sm:text-3xl">
-        <li
-          class="rounded-lg border-2 border-transparent p-2 transition-all hover:border-2 hover:border-primary hover:duration-200"
-          :class="{
-            'border-primary font-bold': route.path === '/',
-          }"
-        >
-          <NuxtLink to="/"> Accueil </NuxtLink>
+        <li>
+          <NuxtLink
+            to="/"
+            class="rounded-lg border-2 border-transparent p-2 transition-all hover:border-2 hover:border-primary hover:duration-200"
+            :class="{ 'border-primary font-bold': route.path === '/' }"
+          >
+            Accueil
+          </NuxtLink>
         </li>
-        <li
-          class="rounded-lg border-2 border-transparent p-2 transition-all hover:border-2 hover:border-primary hover:duration-200"
-          :class="{ 'border-primary font-bold': route.path === '/talks' }"
-        >
-          <NuxtLink to="/talks"> Talks </NuxtLink>
+        <li>
+          <NuxtLink
+            to="/talks"
+            class="rounded-lg border-2 border-transparent p-2 transition-all hover:border-2 hover:border-primary hover:duration-200"
+            :class="{ 'border-primary font-bold': route.path === '/talks' }"
+          >
+            Talks
+          </NuxtLink>
         </li>
-        <!-- <li
-          class="transition-all hover:scale-110 hover:text-slate-100 hover:duration-200"
-        >
-          <NuxtLink to="/news" :class="{ 'font-bold': route.path === '/news' }">
+        <!-- <li>
+          <NuxtLink
+            to="/news"
+            class="transition-all hover:scale-110 hover:text-slate-100 hover:duration-200"
+            :class="{ 'font-bold': route.path === '/news' }"
+          >
             Actus
           </NuxtLink>
         </li> -->
-        <li
-          class="rounded-lg border-2 border-transparent p-2 transition-all hover:border-2 hover:border-primary hover:duration-200"
-          :class="{ 'border-primary font-bold': route.path === '/about' }"
-        >
-          <NuxtLink to="/about"> À propos </NuxtLink>
+        <li>
+          <NuxtLink
+            to="/about"
+            class="rounded-lg border-2 border-transparent p-2 transition-all hover:border-2 hover:border-primary hover:duration-200"
+            :class="{ 'border-primary font-bold': route.path === '/about' }"
+          >
+            À propos
+          </NuxtLink>
         </li>
       </ul>
     </nav>


### PR DESCRIPTION
Hello 👋,

This PR moves the styles from `li` elements to `NuxtLink` components in the `AppHeader` component.

This prevent the anchor to be visually clickable when the user enter the padding (the green border appears) while not being able to click on it because the cursor is on the padding of the `li` element and not on the `a` element.
